### PR TITLE
Fixed bug when parsing link geometries

### DIFF
--- a/robot.cpp
+++ b/robot.cpp
@@ -381,7 +381,7 @@ void robot::readLinks()
                         Link->setColor(visual_geometry_colorElement->Attribute("rgba"));
                 }
             }
-            visualElement = visualElement->NextSiblingElement();
+            visualElement = visualElement->NextSiblingElement("visual");
         }
         //COLLISION
         tinyxml2::XMLNode* collisionElement = linkElement->FirstChildElement("collision");
@@ -430,7 +430,7 @@ void robot::readLinks()
                 } 
 
             }
-            collisionElement = collisionElement->NextSiblingElement();
+            collisionElement = collisionElement->NextSiblingElement("collision");
         }
         
         vLinks.push_back(Link);


### PR DESCRIPTION
Fixed a bug that occurs when a link in the URDF contains both visual- and collision-elements.
Function calls to NextSiblingElement() were missing an optional argument (i.e. "visual" and "collision"). As a result the function did return any xml-sibling. This caused collision-elements to be additionally loaded as visual-elements and vice versa (depending on their order in the URDF).