### PR TITLE
Update link.cpp - Error when importing URDF with Upper Case in mesh filename

### DIFF
--- a/link.cpp
+++ b/link.cpp
@@ -21,8 +21,6 @@ urdfVisualOrCollision::urdfVisualOrCollision()
 std::string strip(const char* filename)
 {
     std::string f(filename);
-    for (size_t i=0;i<f.size();i++)
-        f[i]=std::tolower(f[i]);
     size_t p=f.find("file://");
     if (p!=std::string::npos)
         f=f.substr(7);


### PR DESCRIPTION
There is an error when importing the exported files from the URDF plugin. The mesh filename was converted to lower case and could not be found.